### PR TITLE
Replace "AccessControl::IsUserTheAdministrator" by equivalent logic

### DIFF
--- a/nsis/fainstall.nsi
+++ b/nsis/fainstall.nsi
@@ -1846,12 +1846,13 @@ Function CheckAdminPrivilege
       GoTo PRIVILEGE_TEST_DONE
     ${EndIf}
 
+    ; check by sid (administrator ends with -500)
     AccessControl::GetCurrentUserName
     Pop $0
-    AccessControl::IsUserTheAdministrator $0
+    AccessControl::NameToSid $0
     Pop $0
-    Pop $1
-    ${If} "$1" == "yes"
+    ${WordFind} $0 "-" "-1" $1
+    ${If} $1 == "500"
       GoTo PRIVILEGE_TEST_DONE
     ${EndIf}
 


### PR DESCRIPTION
IsUserTheAdministrator is removed since AccessControl v1.0.5.0, so checking whether it is administrator account, I've used NameToSid and confirmed sid ends with "-500".

See http://support.microsoft.com/kb/243330 for list of sid account.
