### PR TITLE
Add missing double quotes to fix build error on Windows

### DIFF
--- a/nsis/fainstall.nsi
+++ b/nsis/fainstall.nsi
@@ -2214,32 +2214,32 @@ FunctionEnd
 
 !define FillPlaceHolderWithATerm "!insertmacro FillPlaceHolderWithATerm"
 !macro FillPlaceHolderWithATerm Name1 Name2 Name3 Value
-    ${FillPlaceHolder} ${Name1} ${Value}
-    ${FillPlaceHolder} ${Name2} ${Value}
-    ${FillPlaceHolder} ${Name3} ${Value}
+    ${FillPlaceHolder} ${Name1} "${Value}"
+    ${FillPlaceHolder} ${Name2} "${Value}"
+    ${FillPlaceHolder} ${Name3} "${Value}"
 !macroend
 
 !define un.FillPlaceHolderWithATerm "!insertmacro un.FillPlaceHolderWithATerm"
 !macro un.FillPlaceHolderWithATerm Name1 Name2 Name3 Value
-    ${un.FillPlaceHolder} ${Name1} ${Value}
-    ${un.FillPlaceHolder} ${Name2} ${Value}
-    ${un.FillPlaceHolder} ${Name3} ${Value}
+    ${un.FillPlaceHolder} ${Name1} "${Value}"
+    ${un.FillPlaceHolder} ${Name2} "${Value}"
+    ${un.FillPlaceHolder} ${Name3} "${Value}"
 !macroend
 
 !define FillPlaceHolderWithTerms "!insertmacro FillPlaceHolderWithTerms"
 !macro FillPlaceHolderWithTerms Name1 Name2 Name3 Name4 Value
-    ${FillPlaceHolder} ${Name1} ${Value}
-    ${FillPlaceHolder} ${Name2} ${Value}
-    ${FillPlaceHolder} ${Name3} ${Value}
-    ${FillPlaceHolder} ${Name4} ${Value}
+    ${FillPlaceHolder} ${Name1} "${Value}"
+    ${FillPlaceHolder} ${Name2} "${Value}"
+    ${FillPlaceHolder} ${Name3} "${Value}"
+    ${FillPlaceHolder} ${Name4} "${Value}"
 !macroend
 
 !define un.FillPlaceHolderWithTerms "!insertmacro un.FillPlaceHolderWithTerms"
 !macro un.FillPlaceHolderWithTerms Name1 Name2 Name3 Name4 Value
-    ${un.FillPlaceHolder} ${Name1} ${Value}
-    ${un.FillPlaceHolder} ${Name2} ${Value}
-    ${un.FillPlaceHolder} ${Name3} ${Value}
-    ${un.FillPlaceHolder} ${Name4} ${Value}
+    ${un.FillPlaceHolder} ${Name1} "${Value}"
+    ${un.FillPlaceHolder} ${Name2} "${Value}"
+    ${un.FillPlaceHolder} ${Name3} "${Value}"
+    ${un.FillPlaceHolder} ${Name4} "${Value}"
 !macroend
 
 Function "ResolveItemLocation"


### PR DESCRIPTION
In this case, the value of "$%commonprogramfiles%" is treated
as 4 parameters (space separated), so FillPlaceHolder fails.

  !insertmacro: macro "FillPlaceHolder" requires 2 parameter(s), passed 5!
  Error in macro FillPlaceHolderWithTerms on macroline 1
  Error in script "fainstall.nsi" on line 2261 -- aborting creation process
  "Failed to build fainstall.exe!"
