### PR TITLE
Get APP_VERSION correctly on ESR31 or later.

### DIFF
--- a/config.nsh.sample
+++ b/config.nsh.sample
@@ -28,6 +28,7 @@
 ;!define APP_KEY             "Vendor\Something"
 !define APP_MIN_VERSION     "10.0"
 !define APP_MAX_VERSION     "99.99"
+;!define APP_IS_ESR
 ;!define APP_ALLOW_DOWNGRADE
 ;!define APP_DOWNLOAD_PATH   "\\fileserver\shared\Firefox Setup 15.0.1.exe"
 ;!define APP_DOWNLOAD_URL    "http://download.mozilla.org/?product=firefox-15.0.1&os=win&lang=ja"

--- a/nsis/fainstall.nsi
+++ b/nsis/fainstall.nsi
@@ -1776,7 +1776,7 @@ Function un.onUninstSuccess
     ${un.GetOptions} "$0" "/AddonOnly" $1
     ${If} ${Errors}
     ${AndIf} "$APP_VERSION" != ""
-      ReadRegStr $APP_VERSION HKLM "${APP_REG_KEY}" "CurrentVersion"
+      Call un.GetCurrentAppVersion
       ${IfThen} "$APP_VERSION" == "" ${|} GoTo RETURN ${|}
       StrCpy $0 "${APP_REG_KEY}\$APP_VERSION\Main"
       ReadRegStr $APP_DIR HKLM $0 "Install Directory"
@@ -1982,6 +1982,18 @@ Function un.CheckAppProc
     ${EndIf}
 FunctionEnd
 
+!macro GetCurrentAppVersion un
+  Function ${un}GetCurrentAppVersion
+    !ifdef APP_IS_ESR
+      ReadRegStr $APP_VERSION HKLM "${APP_REG_KEY} ESR" "CurrentVersion"
+    !else
+      ReadRegStr $APP_VERSION HKLM "${APP_REG_KEY}" "CurrentVersion"
+    !endif
+  FunctionEnd
+!macroend
+!insertmacro GetCurrentAppVersion ""
+!insertmacro GetCurrentAppVersion "un."
+
 Function GetAppPath
     !ifdef NSIS_CONFIG_LOG
       LogSet on
@@ -1993,7 +2005,7 @@ Function GetAppPath
       LogText "*** GetAppPath: Application installed"
     !endif
 
-    ReadRegStr $APP_VERSION HKLM "${APP_REG_KEY}" "CurrentVersion"
+    Call GetCurrentAppVersion
     ${IfThen} "$APP_VERSION" == "" ${|} GoTo ERR ${|}
     StrCpy $0 "${APP_REG_KEY}\$APP_VERSION\Main"
 


### PR DESCRIPTION
"CurrentVersion"が保存されるレジストリのキーがESR31から変わりました。
HKLM\SOFTWARE\Mozilla\Mozilla Firefox ESR\CurrentVersion
と、" ESR"が付くようになってます。

ちょっとNSISがよく分からなすぎるので、おかしいところがあったら適当に直しちゃってください。
よろしくお願いします。

The key in registry has been changed since ESR31.
See https://bugzilla.mozilla.org/show_bug.cgi?id=726781
