### PR TITLE
WIP: Support TaskbarShortcut for Firefox 47 or later

### DIFF
--- a/doc/usage.txt.ja
+++ b/doc/usage.txt.ja
@@ -927,6 +927,14 @@ QuickLaunchShortcutAllUsers：（省略可能）
   true：全ユーザのクイックランチに適用する。
   false：現在のユーザのクイックランチにのみ適用する。
   省略時はfalseとして扱う。
+TaskbarShortcut：（省略可能）
+  Windows Vista以降のWindowsにおいて、タスクバーのショートカットを
+  （ピン止め状態で）作成するかどうかを指定する。
+  true：タスクバーにショートカットを作成する。
+  false：タスクバーにショートカットを作成しない。
+  省略時はtrueとして扱う。
+  （この指定はFirefox 52以降でのみ利用できる。Firefox 45以前ではタスクバー
+    のショートカットは作成されない）
 MaintenanceService：（省略可能）
   Mozilla Maintenance Serviceのインストールを行うかどうか。
   true：インストールする。


### PR DESCRIPTION
Firefox 47以降（52ESR含む）のデフォルトでは、インストール時にタスクバーのショートカットがピン止め状態で作成されます。
これを防ぐためには、Firefox-setup.iniに以下を追加します。

```
[Install]
TaskbarShortcut=false
```

https://bugzilla.mozilla.org/show_bug.cgi?id=1229626
https://hg.mozilla.org/releases/mozilla-esr52/rev/9ceeaac229de

TODO:

  * [ ] doc/howto.txt.ja
  * [x] doc/usage.txt.ja
  * [ ] fx-install.bat
  * [ ] fx-update.bat
  * [ ] nsis/nsis/fainstall.nsi