### PR TITLE
Use -u (update) for install from scratch

### DIFF
--- a/scripts/download_plugins.sh
+++ b/scripts/download_plugins.sh
@@ -25,7 +25,7 @@ for url in $URI; do
 done
 if [ "$1" = "install" ]; then
     cd plugins
-    ls *.zip | sed -e 's/\.zip$//' | xargs -i unzip -f {}.zip -d {}
+    ls *.zip | sed -e 's/\.zip$//' | xargs -i unzip -u {}.zip -d {}
     find . -name "*.dll" | grep -v -i "unicode" | sudo xargs mv -t /usr/share/nsis/Plugins/
     find . -name "*.nsh" | sudo xargs mv -t /usr/share/nsis/Include/
 fi


### PR DESCRIPTION
When -f option is specified for unzip, it doesn't extract new files on
disk. It is useful option for retrying, but not suitable for first
time.