### PR TITLE
Update fallback shortcut name

### DIFF
--- a/nsis/fainstall.nsi
+++ b/nsis/fainstall.nsi
@@ -867,7 +867,7 @@ Function "CheckShortcutsExistence"
       ReadINIStr $SHORTCUT_NAME "$APP_INSTALLER_INI" "Install" "ShortcutName"
       ReadINIStr $PROGRAM_FOLDER_NAME "$APP_INSTALLER_INI" "Install" "StartMenuDirectoryName"
     ${EndIf}
-    ${IfThen} "$SHORTCUT_NAME" == "" ${|} StrCpy $SHORTCUT_NAME "${APP_FULL_NAME}" ${|}
+    ${IfThen} "$SHORTCUT_NAME" == "" ${|} StrCpy $SHORTCUT_NAME "${APP_NAME}" ${|}
     ${IfThen} "$PROGRAM_FOLDER_NAME" == "" ${|} StrCpy $PROGRAM_FOLDER_NAME "${APP_FULL_NAME}" ${|}
 
     ${LogWithTimestamp} "  SHORTCUT_NAME : $SHORTCUT_NAME"


### PR DESCRIPTION
The default desktop shortcut name was "Mozilla Firefox", but since Firefox ESR60, default shortcut name was changed to "Firefox".

As a result, if user created Firefox.lnk manually on desktop and meta installer was customized with Shortcuts in fainstall.ini, existing user shortcut (Firefox.lnk) will not be updated. Thus, user created desktop shortcut (Firefox.lnk) and meta installer's Firefox.lnk co-exists.

There is a workaround for this behavior - set ShortcutName=Firefox in Firefox-setup.ini, but apparently it should be fixed.