### PR TITLE
Add APP_USE_ACTUAL_INSTALL_DIR (AppUseActualInstallDir) option to accept actual install directory

### DIFF
--- a/doc/usage.ja.md
+++ b/doc/usage.ja.md
@@ -182,6 +182,7 @@ Firefox/Thunderbirdのインストールに関する設定
 | 64bit版かどうか                        | APP_IS_64BIT                            | AppIs64bit                         |
 | ESR版かどうか                          | APP_IS_ESR                              | AppIsESR                           |
 | Developer Editionかどうか              | APP_IS_DEV_EDITION                      | AppIsDevEdition                    |
+| 指定の配置先以外も許容するかどうか     | APP_USE_ACTUAL_INSTALL_DIR              | AppUseActualInstallDir             |
 | ダウングレードの可否                   | APP_ALLOW_DOWNGRADE                     | AppAllowDowngrade                  |
 | ダウングレード後のプロファイル流用可否 | APP_ALLOW_REUSE_PROFILE_AFTER_DOWNGRADE | AppAllowReuseProfileAfterDowngrade |
 | インストーラの設置場所のパス           | APP_DOWNLOAD_PATH                       | AppDownloadPath                    |
@@ -541,6 +542,20 @@ Firefox/Thunderbirdのインストールに関する設定
                              どうかを示す。
 * 取り得る値               ：APP_IS_DEV_EDITIONを定義すると真、未定義だと偽。
 　                           AppIsDevEditionは、true/falseのいずれ
+                             かで指定する。
+* デフォルト値             ：false
+
+### 指定の配置先以外も許容するかどうか（省略可能）
+
+* config.nshでの設定キー   ：APP_USE_ACTUAL_INSTALL_DIR
+* fainstall.iniでの設定キー：[fainstall] > AppUseActualInstallDir
+* 説明                     ：Firefox/Thunderbirdがその環境において
+                             Firefox/Thunderbird-setup.iniで指定された位置以外に
+                             インストールされていた場合に、そのインストール先で
+                             処理を継続するか、指定の配置先へのインストールを
+                             強行するかを示す。
+* 取り得る値               ：APP_USE_ACTUAL_INSTALL_DIRを定義すると真、未定義だと偽。
+　                           AppUseActualInstallDirは、true/falseのいずれ
                              かで指定する。
 * デフォルト値             ：false
 

--- a/nsis/fainstall.nsi
+++ b/nsis/fainstall.nsi
@@ -2582,6 +2582,13 @@ Function GetAppPath
       ${EndIf}
     ${Else}
       ${ReadRegStrSafely} $APP_EXE_PATH "$APP_VERSIONS_ROOT_REG_KEY\$APP_VERSION\Main" "PathToExe"
+      ${If} "$APP_EXE_PATH" == ""
+      ${Then}
+        ${LogWithTimestamp} "  APP_EXE_PATH: 32bit version not found, fallback to 64bit version"
+        SetRegView 64
+        ${ReadRegStrSafely} $APP_EXE_PATH "$APP_VERSIONS_ROOT_REG_KEY\$APP_VERSION\Main" "PathToExe"
+        SetRegView 32
+      ${EndIf}
     ${EndIf}
     ${IfThen} "$APP_EXE_PATH" == "" ${|} GoTo ERR ${|}
 
@@ -2592,13 +2599,20 @@ Function GetAppPath
       SetRegView 64
       ${ReadRegStrSafely} $APP_DIR "$APP_VERSIONS_ROOT_REG_KEY\$APP_VERSION\Main" "Install Directory"
       SetRegView 32
-      ${If} "$APP_EXE_PATH" == ""
+      ${If} "$APP_DIR" == ""
       ${Then}
         ${LogWithTimestamp} "  APP_DIR: 64bit version not found, fallback to 32bit version"
         ${ReadRegStrSafely} $APP_DIR "$APP_VERSIONS_ROOT_REG_KEY\$APP_VERSION\Main" "Install Directory"
       ${EndIf}
     ${Else}
       ${ReadRegStrSafely} $APP_DIR "$APP_VERSIONS_ROOT_REG_KEY\$APP_VERSION\Main" "Install Directory"
+      ${If} "$APP_DIR" == ""
+      ${Then}
+        ${LogWithTimestamp} "  APP_DIR: 32bit version not found, fallback to 64bit version"
+        SetRegView 64
+        ${ReadRegStrSafely} $APP_DIR "$APP_VERSIONS_ROOT_REG_KEY\$APP_VERSION\Main" "Install Directory"
+        SetRegView 32
+      ${EndIf}
     ${EndIf}
     ${IfThen} "$APP_DIR" == "" ${|} GoTo ERR ${|}
 

--- a/nsis/fainstall.nsi
+++ b/nsis/fainstall.nsi
@@ -801,13 +801,17 @@ Section "Cleanup Before Installation" CleanupBeforeInstall
 
         ${LogWithTimestamp} "  Let's run installer"
         ${If} ${FileExists} "$APP_INSTALLER_INI.actual_install_dir"
+          ${LogWithTimestamp} "  with $APP_INSTALLER_INI.actual_install_dir"
           ExecWait '"$APP_INSTALLER_FINAL_PATH" /INI="$APP_INSTALLER_INI.actual_install_dir"'
         ${ElseIf} ${FileExists} "$APP_INSTALLER_INI"
+          ${LogWithTimestamp} "  with $APP_INSTALLER_INI"
           ExecWait '"$APP_INSTALLER_FINAL_PATH" /INI="$APP_INSTALLER_INI"'
         ${Else}
           !if ${APP_INSTALL_MODE} == "QUIET"
+            ${LogWithTimestamp} "  with ${SILENT_INSTALL_OPTIONS}"
             ExecWait '"$APP_INSTALLER_FINAL_PATH" ${SILENT_INSTALL_OPTIONS}'
           !else
+            ${LogWithTimestamp} "  with no option"
             ExecWait '$APP_INSTALLER_FINAL_PATH'
           !endif
         ${EndIf}

--- a/nsis/fainstall.nsi
+++ b/nsis/fainstall.nsi
@@ -147,6 +147,7 @@ ${DefineDefaultValue} APP_IS_64BIT      "false"
 ${DefineDefaultValue} APP_IS_ESR        "false"
 ${DefineDefaultValue} APP_CLEANUP_DIRS ""
 ${DefineDefaultValue} APP_ALLOW_REUSE_PROFILE_AFTER_DOWNGRADE "false"
+${DefineDefaultValue} APP_USE_ACTUAL_INSTALL_DIR "false"
 
 ${DefineDefaultValue} FX_ENABLED_SEARCH_PLUGINS  "*"
 ${DefineDefaultValue} FX_DISABLED_SEARCH_PLUGINS ""
@@ -344,6 +345,7 @@ Var APP_IS_64BIT
 Var APP_IS_ESR
 Var APP_ALLOW_REUSE_PROFILE_AFTER_DOWNGRADE
 Var APP_PROGRAMFILES
+Var APP_USE_ACTUAL_INSTALL_DIR
 
 Var PROCESSING_FILE
 Var RES_DIR
@@ -2594,7 +2596,14 @@ Function GetAppPath
 
   !endif
 
+    ${ReadINIStrWithDefault} $APP_USE_ACTUAL_INSTALL_DIR "${INIPATH}" "${INSTALLER_NAME}" "AppUseActualInstallDir" "${APP_USE_ACTUAL_INSTALL_DIR}"
+    ${If} "$APP_USE_ACTUAL_INSTALL_DIR" == "1"
+    ${OrIf} "$APP_USE_ACTUAL_INSTALL_DIR" == "yes"
+      StrCpy $APP_USE_ACTUAL_INSTALL_DIR "true"
+    ${EndIf}
+
     ${If} ${FileExists} "$APP_INSTALLER_INI"
+    ${AndIf} "$APP_USE_ACTUAL_INSTALL_DIR" != "true"
       ReadINIStr $INI_TEMP "$APP_INSTALLER_INI" "Install" "InstallDirectoryName"
       ${LogWithTimestamp} "  InstallDirectoryName: $INI_TEMP"
       ReadINIStr $INI_TEMP2 "$APP_INSTALLER_INI" "Install" "InstallDirectoryPath"

--- a/nsis/fainstall.nsi
+++ b/nsis/fainstall.nsi
@@ -2548,12 +2548,25 @@ FunctionEnd
     Call ${un}GetCurrentAppRegKey
     ${If} "$APP_IS_64BIT" == "true"
       SetRegView 64
+      ${ReadRegStrSafely} $APP_VERSION "$APP_REG_KEY" "CurrentVersion"
+      SetRegView 32
+      ${If} "$APP_VERSION" == ""
+      ${Then}
+        ${LogWithTimestamp} "  APP_VERSION: 64bit version not found, fallback to 32bit version"
+        ${ReadRegStrSafely} $APP_VERSION "$APP_REG_KEY" "CurrentVersion"
+      ${EndIf}
+    ${Else}
+      ${ReadRegStrSafely} $APP_VERSION "$APP_REG_KEY" "CurrentVersion"
+      ${If} "$APP_VERSION" == ""
+      ${Then}
+        ${LogWithTimestamp} "  APP_VERSION: 32bit version not found, fallback to 64bit version"
+        SetRegView 64
+        ${ReadRegStrSafely} $APP_VERSION "$APP_REG_KEY" "CurrentVersion"
+        SetRegView 32
+      ${EndIf}
     ${EndIf}
     ${ReadRegStrSafely} $APP_VERSION "$APP_REG_KEY" "CurrentVersion"
     ;MessageBox MB_OK|MB_ICONEXCLAMATION "APP_IS_64BIT = $APP_IS_64BIT / APP_REG_KEY = $APP_REG_KEY / APP_VERSION = $APP_VERSION" /SD IDOK
-    ${If} "$APP_IS_64BIT" == "true"
-      SetRegView 32
-    ${EndIf}
   FunctionEnd
 !macroend
 !insertmacro GetCurrentAppVersion ""
@@ -2563,7 +2576,7 @@ Function GetAppPath
     ${LogWithTimestamp} "GetAppPath"
     ${IfThen} "$APP_INSTALLED" != "1" ${|} StrCpy $APP_INSTALLED "0" ${|}
 
-    ${LogWithTimestamp} "  Application installed"
+    ${LogWithTimestamp} "  Checking application installed path"
 
   !if ${APP_INSTALL_MODE} != "EXTRACT"
 

--- a/nsis/fainstall.nsi
+++ b/nsis/fainstall.nsi
@@ -2573,10 +2573,15 @@ Function GetAppPath
     ; EXE path
     ${If} "$APP_IS_64BIT" == "true"
       SetRegView 64
-    ${EndIf}
-    ${ReadRegStrSafely} $APP_EXE_PATH "$APP_VERSIONS_ROOT_REG_KEY\$APP_VERSION\Main" "PathToExe"
-    ${If} "$APP_IS_64BIT" == "true"
+      ${ReadRegStrSafely} $APP_EXE_PATH "$APP_VERSIONS_ROOT_REG_KEY\$APP_VERSION\Main" "PathToExe"
       SetRegView 32
+      ${If} "$APP_EXE_PATH" == ""
+      ${Then}
+        ${LogWithTimestamp} "  APP_EXE_PATH: 64bit version not found, fallback to 32bit version"
+        ${ReadRegStrSafely} $APP_EXE_PATH "$APP_VERSIONS_ROOT_REG_KEY\$APP_VERSION\Main" "PathToExe"
+      ${EndIf}
+    ${Else}
+      ${ReadRegStrSafely} $APP_EXE_PATH "$APP_VERSIONS_ROOT_REG_KEY\$APP_VERSION\Main" "PathToExe"
     ${EndIf}
     ${IfThen} "$APP_EXE_PATH" == "" ${|} GoTo ERR ${|}
 
@@ -2585,10 +2590,15 @@ Function GetAppPath
     ; Application directory
     ${If} "$APP_IS_64BIT" == "true"
       SetRegView 64
-    ${EndIf}
-    ${ReadRegStrSafely} $APP_DIR "$APP_VERSIONS_ROOT_REG_KEY\$APP_VERSION\Main" "Install Directory"
-    ${If} "$APP_IS_64BIT" == "true"
+      ${ReadRegStrSafely} $APP_DIR "$APP_VERSIONS_ROOT_REG_KEY\$APP_VERSION\Main" "Install Directory"
       SetRegView 32
+      ${If} "$APP_EXE_PATH" == ""
+      ${Then}
+        ${LogWithTimestamp} "  APP_DIR: 64bit version not found, fallback to 32bit version"
+        ${ReadRegStrSafely} $APP_DIR "$APP_VERSIONS_ROOT_REG_KEY\$APP_VERSION\Main" "Install Directory"
+      ${EndIf}
+    ${Else}
+      ${ReadRegStrSafely} $APP_DIR "$APP_VERSIONS_ROOT_REG_KEY\$APP_VERSION\Main" "Install Directory"
     ${EndIf}
     ${IfThen} "$APP_DIR" == "" ${|} GoTo ERR ${|}
 

--- a/nsis/fainstall.nsi
+++ b/nsis/fainstall.nsi
@@ -2551,14 +2551,12 @@ FunctionEnd
       ${ReadRegStrSafely} $APP_VERSION "$APP_REG_KEY" "CurrentVersion"
       SetRegView 32
       ${If} "$APP_VERSION" == ""
-      ${Then}
         ${LogWithTimestamp} "  APP_VERSION: 64bit version not found, fallback to 32bit version"
         ${ReadRegStrSafely} $APP_VERSION "$APP_REG_KEY" "CurrentVersion"
       ${EndIf}
     ${Else}
       ${ReadRegStrSafely} $APP_VERSION "$APP_REG_KEY" "CurrentVersion"
       ${If} "$APP_VERSION" == ""
-      ${Then}
         ${LogWithTimestamp} "  APP_VERSION: 32bit version not found, fallback to 64bit version"
         SetRegView 64
         ${ReadRegStrSafely} $APP_VERSION "$APP_REG_KEY" "CurrentVersion"
@@ -2589,14 +2587,12 @@ Function GetAppPath
       ${ReadRegStrSafely} $APP_EXE_PATH "$APP_VERSIONS_ROOT_REG_KEY\$APP_VERSION\Main" "PathToExe"
       SetRegView 32
       ${If} "$APP_EXE_PATH" == ""
-      ${Then}
         ${LogWithTimestamp} "  APP_EXE_PATH: 64bit version not found, fallback to 32bit version"
         ${ReadRegStrSafely} $APP_EXE_PATH "$APP_VERSIONS_ROOT_REG_KEY\$APP_VERSION\Main" "PathToExe"
       ${EndIf}
     ${Else}
       ${ReadRegStrSafely} $APP_EXE_PATH "$APP_VERSIONS_ROOT_REG_KEY\$APP_VERSION\Main" "PathToExe"
       ${If} "$APP_EXE_PATH" == ""
-      ${Then}
         ${LogWithTimestamp} "  APP_EXE_PATH: 32bit version not found, fallback to 64bit version"
         SetRegView 64
         ${ReadRegStrSafely} $APP_EXE_PATH "$APP_VERSIONS_ROOT_REG_KEY\$APP_VERSION\Main" "PathToExe"
@@ -2613,14 +2609,12 @@ Function GetAppPath
       ${ReadRegStrSafely} $APP_DIR "$APP_VERSIONS_ROOT_REG_KEY\$APP_VERSION\Main" "Install Directory"
       SetRegView 32
       ${If} "$APP_DIR" == ""
-      ${Then}
         ${LogWithTimestamp} "  APP_DIR: 64bit version not found, fallback to 32bit version"
         ${ReadRegStrSafely} $APP_DIR "$APP_VERSIONS_ROOT_REG_KEY\$APP_VERSION\Main" "Install Directory"
       ${EndIf}
     ${Else}
       ${ReadRegStrSafely} $APP_DIR "$APP_VERSIONS_ROOT_REG_KEY\$APP_VERSION\Main" "Install Directory"
       ${If} "$APP_DIR" == ""
-      ${Then}
         ${LogWithTimestamp} "  APP_DIR: 32bit version not found, fallback to 64bit version"
         SetRegView 64
         ${ReadRegStrSafely} $APP_DIR "$APP_VERSIONS_ROOT_REG_KEY\$APP_VERSION\Main" "Install Directory"

--- a/nsis/fainstall.nsi
+++ b/nsis/fainstall.nsi
@@ -2569,7 +2569,6 @@ FunctionEnd
         SetRegView 32
       ${EndIf}
     ${EndIf}
-    ${ReadRegStrSafely} $APP_VERSION "$APP_REG_KEY" "CurrentVersion"
     ;MessageBox MB_OK|MB_ICONEXCLAMATION "APP_IS_64BIT = $APP_IS_64BIT / APP_REG_KEY = $APP_REG_KEY / APP_VERSION = $APP_VERSION" /SD IDOK
   FunctionEnd
 !macroend


### PR DESCRIPTION
# 背景説明

現行版ではFirefox/Thunderbirdのインストール先は Firefox/Thunderbird-setup.ini での指定を最優先するようになっています。
Firefox/Thunderbird-setup.ini でインストール先が明示されていない場合は、既定のインストール先が使われる物と推定します。

他方、Firefox/Thunderbirdのインストーラは、Firefox/Thunderbird-setup.ini でインストール先が明示されておらず、且つ、既にその環境にFirefox/Thunderbirdがインストールされている場合、既定のインストール先ではなく最後のインストール先を上書きするようになっています。

そのため、

* Firefox/Thunderbird-setup.ini でインストール先が明示されていない
* 既にその環境にFirefox/Thunderbirdがインストールされていて、インストール先の位置が、メタインストーラ同梱のFirefox/Thunderbirdの既定のインストール先とは異なる（例：32bit版に代わり64bit版を使うようにした、など）

という2つの条件が満たされると、メタインストーラの実行時に

* Firefox/Thunderbirdのインストーラは、実際のインストール先にあるFirefox/Thunderbirdを上書きする。
  * その際、Firefox/Thunderbirdのインストーラが distribution フォルダーなどカスタマイズ用のファイルを削除する。
* メタインストーラは、期待されるインストール先（既定のインストール先）にFirefox/Thunderbirdがインストールされなかったと判定する。

ということが起こり、インストールに失敗することになります。

# 変更内容の説明

この変更では、APP_USE_ACTUAL_INSTALL_DIR (AppUseActualInstallDir) という設定を追加します（既定値false）
この設定の値がtrueだと、メタインストーラはその環境にインストール済みのFirefox/Thunderbirdを検出した際に、現在のインストール先のパスへのインストールとなるようなFirefox/Thunderbird-setup.ini を自動生成して、そちらを使うようになります。
これにより、インストール先が一定しない状態のメタインストーラが過去に使われた環境において、32bit版から64bit版へのアップグレードのように既定のインストール先が異なる設定のメタインストーラを使用して、現在のインストール先のFirefox/Thunderbirdを確実に上書き更新できるようになります。