### PR TITLE
fix unexpected redirect

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -50,7 +50,7 @@ cd nsis
 inifile=../fainstall.ini
 
 has_config() {
-  cat ../config.nsh | grep -v -E "^;" | grep $1 >/dev/null 2&>1
+  cat ../config.nsh | grep -v -E "^;" | grep $1 >/dev/null 2>&1
 }
 
 read_config() {


### PR DESCRIPTION
2&>1 result in generating file `1`.
It should be `2>&1` (redirect and merge).