### PR TITLE
Detect city hash of Thunderbird 64bit version correctly

### DIFF
--- a/nsis/fainstall.nsi
+++ b/nsis/fainstall.nsi
@@ -738,6 +738,8 @@ Function InitializeLocalizedResDir
     StrCpy $FULL_LOCALE_CODE ""
     StrCpy $SHORT_LOCALE_CODE ""
 
+    Call GetAppPath
+
     SetRegView 64
     ${LogWithTimestamp} "  detecting locale from prefs (64bit)"
     Call TryDetectLocaleFromPref
@@ -809,8 +811,6 @@ Function InitializeLocalizedResDir
 FunctionEnd
 
 Function TryDetectLocaleFromPref
-    Call GetAppPath
-
     ${LogWithTimestamp} "  getting city hash: Software\Mozilla\${APP_NAME}\TaskBarIDs / $APP_DIR"
     ${ReadRegStrSafely} $CITY_HASH "Software\Mozilla\${APP_NAME}\TaskBarIDs" "$APP_DIR"
     ${LogWithTimestamp} "   => $CITY_HASH"


### PR DESCRIPTION
ユーザープロファイルの位置をレジストリーの値から辿る際に、64bit版Thunderbirdのレジストリーの値を読み取るべくSetRegView 64していたものの、TryDetectLocaleFromPref内で呼んでいるGetAppPathの中で「SetRegView 64して、SetRegView 32に戻す」としていたせいで、32bit版Thunderbirdのレジストリー値しか読み込めない状況でした。
GetAppPathの呼び出し位置を変え、TryDetectLocaleFromPref直前のSetRegView 64が有効に機能するように修正しています。