### PR TITLE
Support lang code part like "(x64 ja)"

### DIFF
--- a/nsis/fainstall.nsi
+++ b/nsis/fainstall.nsi
@@ -865,7 +865,7 @@ FunctionEnd
 
 Function ExtractLangCodePart
     Pop $R0
-    ${StrTok} $R1 "$R0" " " -1 0
+    ${StrTok} $R1 "$R0" " " "L" 1
     Push $R1
 FunctionEnd
 

--- a/nsis/fainstall.nsi
+++ b/nsis/fainstall.nsi
@@ -865,7 +865,7 @@ FunctionEnd
 
 Function ExtractLangCodePart
     Pop $R0
-    ${StrTok} $R1 "$R0 " " -1
+    ${StrTok} $R1 "$R0" " " -1
     Push $R1
 FunctionEnd
 

--- a/nsis/fainstall.nsi
+++ b/nsis/fainstall.nsi
@@ -785,6 +785,12 @@ Function InitializeLocalizedResDir
       StrCpy $FULL_LOCALE_CODE "en-US"
     ${EndIf}
 
+    ${LogWithTimestamp} "  extracting locale code part"
+    Push $FULL_LOCALE_CODE
+    Call ExtractLangCodePart
+    Pop $FULL_LOCALE_CODE
+    ${LogWithTimestamp} "   => $FULL_LOCALE_CODE"
+
     Push $FULL_LOCALE_CODE
     Call ExtractLocaleName
     Pop $SHORT_LOCALE_CODE
@@ -855,6 +861,29 @@ Function ExtractParens
     ${StrTok} $R1 "$R0" '(' 1 1
     ${StrTok} $R2 "$R1" ')' 0 1
     Push $R2
+FunctionEnd
+
+Function ExtractLangCodePart
+    Exch $0
+    Push $1
+    Push $2
+
+    StrLen $1 $0
+    StrCpy $2 $1
+
+    ${DoWhile} $2 > 0
+      IntOp $2 $2 - 1
+      StrCpy $3 $0 1 $2
+      ${If} $3 == " "
+        IntOp $2 $2 + 1
+        StrCpy $0 $0 "" $2
+        ${Break}
+      ${EndIf}
+    ${Loop}
+
+    Pop $2
+    Pop $1
+    Exch $0
 FunctionEnd
 
 Function ExtractLocaleName

--- a/nsis/fainstall.nsi
+++ b/nsis/fainstall.nsi
@@ -865,24 +865,7 @@ FunctionEnd
 
 Function ExtractLangCodePart
     Exch $0
-    Push $1
-    Push $2
-
-    StrLen $1 $0
-    StrCpy $2 $1
-
-    ${DoWhile} $2 > 0
-      IntOp $2 $2 - 1
-      StrCpy $3 $0 1 $2
-      ${If} $3 == " "
-        IntOp $2 $2 + 1
-        StrCpy $0 $0 "" $2
-        ${Break}
-      ${EndIf}
-    ${Loop}
-
-    Pop $2
-    Pop $1
+    ${StrTok} $0 $0 " " -1
     Exch $0
 FunctionEnd
 

--- a/nsis/fainstall.nsi
+++ b/nsis/fainstall.nsi
@@ -864,9 +864,9 @@ Function ExtractParens
 FunctionEnd
 
 Function ExtractLangCodePart
-    Exch $0
-    ${StrTok} $0 $0 " " -1
-    Exch $0
+    Pop $R0
+    ${StrTok} $R1 "$R0 " " -1
+    Push $R1
 FunctionEnd
 
 Function ExtractLocaleName

--- a/nsis/fainstall.nsi
+++ b/nsis/fainstall.nsi
@@ -865,7 +865,7 @@ FunctionEnd
 
 Function ExtractLangCodePart
     Pop $R0
-    ${StrTok} $R1 "$R0" " " -1
+    ${StrTok} $R1 "$R0" " " -1 0
     Push $R1
 FunctionEnd
 


### PR DESCRIPTION
最近のバージョンでThunderbird（Firefoxも？）のインストーラーがレジストリーに登録するバージョン番号の言語コード部分が `(ja)` のような表記から `(x64 ja)' のようにアーキテクチャ名を含む表記に変わったため、言語コードの識別に失敗するようになっています。その修正のための対応として、空白文字がある場合は最後のパートを取り出して使うようにする変更です。