### PR TITLE
Cleanup ITEMS_LIST before collecting installed addons.

### DIFF
--- a/nsis/fainstall.nsi
+++ b/nsis/fainstall.nsi
@@ -1583,6 +1583,7 @@ Section "Install Add-ons" InstallAddons
     ${If} "$STATIC_ADDONS_LIST" != ""
       StrCpy $ITEMS_LIST "$STATIC_ADDONS_LIST"
     ${Else}
+      StrCpy $ITEMS_LIST ""
       ${Locate} "$RES_DIR" "/L=F /G=0 /M=*.xpi" "CollectAddonFiles"
       ${Locate} "$LOCALIZED_RES_DIR" "/L=F /G=0 /M=*.xpi" "CollectAddonFiles"
       ${Locate} "$FULL_LOCALIZED_RES_DIR" "/L=F /G=0 /M=*.xpi" "CollectAddonFiles"


### PR DESCRIPTION
It may be filled with previous operation, so the previous value will be misdetected as addons to be installed.